### PR TITLE
refactor(secrets/s3): s3 custom endpoint

### DIFF
--- a/kork-secrets-aws/kork-secrets-aws.gradle
+++ b/kork-secrets-aws/kork-secrets-aws.gradle
@@ -6,4 +6,8 @@ dependencies {
   api project(':kork-secrets')
 
   implementation "com.amazonaws:aws-java-sdk-s3"
+
+  compileOnly 'org.projectlombok:lombok:1.18.10'
+
+  annotationProcessor 'org.projectlombok:lombok:1.18.10'
 }

--- a/kork-secrets-aws/kork-secrets-aws.gradle
+++ b/kork-secrets-aws/kork-secrets-aws.gradle
@@ -7,7 +7,7 @@ dependencies {
 
   implementation "com.amazonaws:aws-java-sdk-s3"
 
-  compileOnly 'org.projectlombok:lombok:1.18.10'
+  compileOnly 'org.projectlombok:lombok:+'
 
-  annotationProcessor 'org.projectlombok:lombok:1.18.10'
+  annotationProcessor 'org.projectlombok:lombok:+'
 }

--- a/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/S3Configuration.java
+++ b/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/S3Configuration.java
@@ -20,25 +20,25 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 @Getter
 @Component
 @Configuration
-@ConditionalOnExpression("${secrets.s3.enabled:false}")
+@ConditionalOnProperty("secrets.s3.enabled")
 @Slf4j
 public class S3Configuration {
 
-  private String s3Url;
+  private String endpointUrl;
   private boolean pathStyleAccessEnabled;
 
   @Autowired
   public S3Configuration(
-      @Value("${secrets.s3.endpoint-url:}") String s3Url,
-      @Value("${secrets.s3.path-style-access-enabled:}") String pathStyleAccessEnabled) {
-    this.s3Url = s3Url;
-    this.pathStyleAccessEnabled = Boolean.parseBoolean(pathStyleAccessEnabled);
+      @Value("${secrets.s3.endpoint-url}") String endpointUrl,
+      @Value("${secrets.s3.path-style-access-enabled}") boolean pathStyleAccessEnabled) {
+    this.endpointUrl = endpointUrl;
+    this.pathStyleAccessEnabled = pathStyleAccessEnabled;
   }
 }

--- a/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/S3Configuration.java
+++ b/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/S3Configuration.java
@@ -36,8 +36,8 @@ public class S3Configuration {
 
   @Autowired
   public S3Configuration(
-      @Value("${secrets.s3.endpointUrl:}") String s3Url,
-      @Value("${secrets.s3.pathStyleAccessEnabled:}") String pathStyleAccessEnabled) {
+      @Value("${secrets.s3.endpoint-url:}") String s3Url,
+      @Value("${secrets.s3.path-style-access-enabled:}") String pathStyleAccessEnabled) {
     this.s3Url = s3Url;
     this.pathStyleAccessEnabled = Boolean.parseBoolean(pathStyleAccessEnabled);
   }

--- a/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/S3Configuration.java
+++ b/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/S3Configuration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.kork.secrets.engines;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@Configuration
+@ConditionalOnExpression("${secrets.s3.enabled:false}")
+@Slf4j
+public class S3Configuration {
+
+  private String s3Url;
+  private boolean pathStyleAccessEnabled;
+
+  @Autowired
+  public S3Configuration(
+      @Value("${secrets.s3.endpointUrl:}") String s3Url,
+      @Value("${secrets.s3.pathStyleAccessEnabled:}") String pathStyleAccessEnabled) {
+    this.s3Url = s3Url;
+    this.pathStyleAccessEnabled = Boolean.parseBoolean(pathStyleAccessEnabled);
+  }
+}

--- a/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/S3SecretEngine.java
+++ b/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/S3SecretEngine.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import com.netflix.spinnaker.kork.secrets.SecretException;
 import java.io.IOException;
 import java.io.InputStream;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -49,7 +50,7 @@ public class S3SecretEngine extends AbstractStorageSecretEngine {
     String objName = encryptedSecret.getParams().get(STORAGE_FILE_URI);
 
     AmazonS3ClientBuilder s3ClientBuilder = AmazonS3ClientBuilder.standard();
-    if (s3Configuration.getS3Url().isEmpty()) {
+    if (StringUtils.isBlank(s3Configuration.getS3Url())) {
       s3ClientBuilder = s3ClientBuilder.withRegion(region);
     } else {
       s3ClientBuilder.setEndpointConfiguration(

--- a/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/S3SecretEngine.java
+++ b/kork-secrets-aws/src/main/java/com/netflix/spinnaker/kork/secrets/engines/S3SecretEngine.java
@@ -50,11 +50,11 @@ public class S3SecretEngine extends AbstractStorageSecretEngine {
     String objName = encryptedSecret.getParams().get(STORAGE_FILE_URI);
 
     AmazonS3ClientBuilder s3ClientBuilder = AmazonS3ClientBuilder.standard();
-    if (StringUtils.isBlank(s3Configuration.getS3Url())) {
+    if (StringUtils.isBlank(s3Configuration.getEndpointUrl())) {
       s3ClientBuilder = s3ClientBuilder.withRegion(region);
     } else {
       s3ClientBuilder.setEndpointConfiguration(
-          new AwsClientBuilder.EndpointConfiguration(s3Configuration.getS3Url(), region));
+          new AwsClientBuilder.EndpointConfiguration(s3Configuration.getEndpointUrl(), region));
       s3ClientBuilder.setPathStyleAccessEnabled(s3Configuration.isPathStyleAccessEnabled());
     }
 


### PR DESCRIPTION
In order to use another storage system like for example Minio, this change allows to set a custom endpoint url to the s3 secret configuration.